### PR TITLE
inline example using -j

### DIFF
--- a/docs/man/msplit.md
+++ b/docs/man/msplit.md
@@ -74,7 +74,7 @@ If you are using the -j option, the object will be parsed as json and bound to
 
 You can use the first 9 characters of the id field with:
 
-    $ ... | msplit -e "this.id.substring(0,9)" -n 4
+    $ ... | msplit -j -e "this.id.substring(0,9)" -n 4
 
 EXAMPLES
 --------


### PR DESCRIPTION
Match the syntax of the inline example with the example at the bottom, using -j to force json handling
